### PR TITLE
Corrected typo within payWithPaystack method

### DIFF
--- a/src/vue3-paystack.vue
+++ b/src/vue3-paystack.vue
@@ -115,8 +115,8 @@ export default /*#__PURE__*/defineComponent({
         onSuccess: (response) => {
           this.onSuccess(response);
         },
-        onCanel: () => {
-          this.onCanel();
+        onCancel: () => {
+          this.onCancel();
         },
         // onBankTransferConfirmationPending: function(response) {
         //   this.onBankTransferConfirmationPending(response);


### PR DESCRIPTION
Corrected typo in 'onCanel' called within payWithPaystack() method which referenced onCancel props